### PR TITLE
Align chart data with new backend endpoints

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -146,6 +146,13 @@ export class ApiClient {
     );
     return response.json();
   }
+
+  async getRepositoryPatterns(id: string, includeOccurrences = true) {
+    const response = await fetch(
+      `${this.baseUrl}/api/repositories/${id}/patterns?include_occurrences=${includeOccurrences}`
+    );
+    return response.json();
+  }
 }
 
 // Export singleton instance

--- a/frontend/src/components/features/AnalysisDashboard.tsx
+++ b/frontend/src/components/features/AnalysisDashboard.tsx
@@ -26,6 +26,7 @@ import { ComplexityEvolutionChart } from "../charts/ComplexityEvolutionChart";
 import { LearningProgressionChart } from "../charts/LearningProgressionChart";
 import { TechStackComposition } from "../charts/TechStackComposition";
 import { TechnologyRelationshipGraph } from "../charts/TechnologyRelationshipGraph";
+import { useRepositoryPatterns } from "../../hooks/useRepositoryPatterns";
 import { InsightsDashboard } from "./InsightsDashboard";
 import { PatternDeepDive } from "./PatternDeepDive";
 import { CodeQualityDashboard } from "./CodeQualityDashboard";
@@ -44,6 +45,12 @@ export const AnalysisDashboard: React.FC<AnalysisDashboardProps> = ({
     isLoading,
     error,
   } = useRepositoryAnalysis(repositoryId);
+  const { data: patternDetails } = useRepositoryPatterns(repositoryId);
+
+  const allOccurrences = useMemo(() => {
+    if (!patternDetails?.patterns) return [];
+    return (patternDetails.patterns as any[]).flatMap((p: any) => p.occurrences || []);
+  }, [patternDetails]);
   // Validate analysis data structure
   console.log("Analysis data:", analysis);
   if (analysis && !analysis.pattern_statistics) {
@@ -218,7 +225,7 @@ export const AnalysisDashboard: React.FC<AnalysisDashboardProps> = ({
               <DashboardCard title="Pattern Deep Dive" icon={Brain}>
                 <PatternDeepDive
                   patterns={analysis.pattern_statistics}
-                  occurrences={analysis.patterns}
+                  occurrences={allOccurrences}
                 />
               </DashboardCard>
             </TabsContent>

--- a/frontend/src/hooks/useRepositoryPatterns.ts
+++ b/frontend/src/hooks/useRepositoryPatterns.ts
@@ -1,0 +1,11 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { apiClient } from "../api/client";
+
+export const useRepositoryPatterns = (
+  repoId: string | null
+): UseQueryResult<any, Error> =>
+  useQuery<any, Error>({
+    queryKey: ["repositoryPatterns", repoId],
+    queryFn: () => apiClient.getRepositoryPatterns(repoId!),
+    enabled: !!repoId,
+  });


### PR DESCRIPTION
## Summary
- adjust repository analysis API to include a single analysis_session and flattened pattern occurrences
- expose new `/api/repositories/{id}/patterns` endpoint
- update frontend API client and dashboard to load pattern occurrences via new hook

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840f09abf3c8323a0627f10e6a53342